### PR TITLE
fix PostgreSQL when first time install on k8s

### DIFF
--- a/installer/charts/hive-metastore/values.yaml
+++ b/installer/charts/hive-metastore/values.yaml
@@ -31,6 +31,11 @@ hive-metastore-postgresql:
     username: hive
     password: E9mZ424xCUt3
     database: metastore
+  primary:
+      readinessProbe:
+        initialDelaySeconds: 300
+      livenessProbe:
+        initialDelaySeconds: 300
 
 ## Resource requests and limits: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 resources:

--- a/installer/charts/hive-metastore/values.yaml
+++ b/installer/charts/hive-metastore/values.yaml
@@ -32,10 +32,10 @@ hive-metastore-postgresql:
     password: E9mZ424xCUt3
     database: metastore
   primary:
-      readinessProbe:
-        initialDelaySeconds: 300
-      livenessProbe:
-        initialDelaySeconds: 300
+    readinessProbe:
+      initialDelaySeconds: 300
+    livenessProbe:
+      initialDelaySeconds: 300
 
 ## Resource requests and limits: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 resources:

--- a/installer/charts/lighter/values.yaml
+++ b/installer/charts/lighter/values.yaml
@@ -66,6 +66,11 @@ lighter-postgresql:
     username: lighter
     password: mU233@t3PqXP
     database: lighter
+  primary:
+      readinessProbe:
+        initialDelaySeconds: 300
+      livenessProbe:
+        initialDelaySeconds: 300
 
 s3a:
   endpoint: https://empty

--- a/installer/charts/lighter/values.yaml
+++ b/installer/charts/lighter/values.yaml
@@ -67,10 +67,10 @@ lighter-postgresql:
     password: mU233@t3PqXP
     database: lighter
   primary:
-      readinessProbe:
-        initialDelaySeconds: 300
-      livenessProbe:
-        initialDelaySeconds: 300
+    readinessProbe:
+      initialDelaySeconds: 300
+    livenessProbe:
+      initialDelaySeconds: 300
 
 s3a:
   endpoint: https://empty


### PR DESCRIPTION
Delay the PostgreSQL startup initially during PVC provisioning, to allow enough time to create the username and password.